### PR TITLE
Use ghcr.io/riscv/riscv-docs-base-container-image:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION ?= v0.0.0
 REVMARK ?= Draft
 ifneq ($(SKIP_DOCKER),true)
 	DOCKER_CMD := docker run --rm -v ${PWD}:/build -w /build \
-	riscvintl/riscv-docs-base-container-image:latest \
+	ghcr.io/riscv/riscv-docs-base-container-image:latest \
 	/bin/sh -c
 	DOCKER_QUOTE := "
 endif


### PR DESCRIPTION
This updates the docs container image reference in the root Makefile.

The old `riscvintl` image has been replaced with the `ghcr.io/riscv` image.
