### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -61,7 +61,7 @@ jobs:
 
       # Upload the built PDF files as a single artifact
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Build Artifacts
           path: ${{ github.workspace }}/build/*.pdf
@@ -69,7 +69,7 @@ jobs:
 
       # Create Release
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ github.workspace }}/build/*.pdf
           tag_name: v${{ github.event.inputs.version }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '>=3.11'


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
